### PR TITLE
Let us use “npm start” to make the podcast.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Teach the Web Podcast",
   "main": "make.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node make.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I flip-flopped between using "start" (for ease of running, although it makes slightly less sense) and using "build" (which makes more sense but would force us to use `npm run build` instead of `npm start`).  I went with the former.
